### PR TITLE
Update package.json so jaws module successfully installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "devDependencies": {},
   "dependencies": {
     "bluebird": "^2.10.1",
-    "twilio": "^2.5.0",
+    "twilio": "^2.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "devDependencies": {},
   "dependencies": {
     "bluebird": "^2.10.1",
-    "twilio": "^2.5.0"
+    "twilio": "^2.4.0"
   }
 }


### PR DESCRIPTION
npm was complaining about the trailing comma and the Twilio `^2.5.0` dependency was not resolving. PR fixes both issues.
